### PR TITLE
Compatibility patch with Questionable Ethics Enhanced

### DIFF
--- a/Patches/EVO_F_QuestionableEthics.xml
+++ b/Patches/EVO_F_QuestionableEthics.xml
@@ -1,9 +1,125 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
+	<!--In this patch, QE = 'Questionable Ethics' mod and QEE = 'Questionable Ethics Enhanced' mod-->
+
+	<!--Apply patches to QE only, not QEE-->
 	<Operation Class="PatchOperationFindMod">
 		<success>Always</success>
 		<mods>
 			<li>Questionable Ethics</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<li Class="PatchOperationReplace"> 
+					<!--moving this to 5x, 2y default is 3x, 3y-->
+					<xpath>/Defs/ResearchProjectDef[defName="QE_LifeSupportSystem"]/researchViewX</xpath>
+					<value>
+						<researchViewX>4</researchViewX>
+					</value>
+					</li>
+					<li Class="PatchOperationReplace">
+					<xpath>/Defs/ResearchProjectDef[defName="QE_LifeSupportSystem"]/researchViewY</xpath>
+					<value>
+						<researchViewY>0</researchViewY>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<!--moving this to 5x, 1y default is 4x, 3y-->
+					<xpath>/Defs/ResearchProjectDef[defName="QE_NerveStapling"]/researchViewX</xpath>
+					<value>
+						<researchViewX>5</researchViewX>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ResearchProjectDef[defName="QE_NerveStapling"]/researchViewY</xpath>
+					<value>
+						<researchViewY>1</researchViewY>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace"> 
+					<!--moving this to 5x, 3y default is 4x, 4y-->
+					<xpath>/Defs/ResearchProjectDef[defName="QE_CrudeBionics"]/researchViewX</xpath>
+					<value>
+						<researchViewX>1</researchViewX>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ResearchProjectDef[defName="QE_CrudeBionics"]/researchViewY</xpath>
+					<value>
+						<researchViewY>5</researchViewY>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<!--moving this to 4x, 4y default is 5x, 3y-->
+					<xpath>/Defs/ResearchProjectDef[defName="QE_IntegratedWeaponry"]/researchViewX</xpath>
+					<value>
+						<researchViewX>2</researchViewX>
+					</value>
+					</li>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ResearchProjectDef[defName="QE_IntegratedWeaponry"]/researchViewY</xpath>
+					<value>
+						<researchViewY>5</researchViewY>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<!--moving this to 4x, 4y default is 5x, 3y-->
+					<xpath>/Defs/ResearchProjectDef[defName="QE_GenomeSequencing"]/researchViewX</xpath>
+					<value>
+						<researchViewX>2</researchViewX>
+					</value>
+					</li>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ResearchProjectDef[defName="QE_GenomeSequencing"]/researchViewY</xpath>
+					<value>
+						<researchViewY>2</researchViewY>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<!--moving this to 4x, 4y default is 5x, 3y-->
+					<xpath>/Defs/ResearchProjectDef[defName="QE_VatGrownBeings"]/researchViewX</xpath>
+					<value>
+						<researchViewX>3</researchViewX>
+					</value>
+					</li>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ResearchProjectDef[defName="QE_VatGrownBeings"]/researchViewY</xpath>
+					<value>
+						<researchViewY>2</researchViewY>
+					</value>
+				</li>
+
+				
+				<li Class="PatchOperationReplace">
+					<!--moving this to 4x, 4y default is 5x, 3y-->
+					<xpath>/Defs/ResearchProjectDef[defName="QE_BrainScanning"]/researchViewX</xpath>
+					<value>
+						<researchViewX>4</researchViewX>
+					</value>
+					</li>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ResearchProjectDef[defName="QE_BrainScanning"]/researchViewY</xpath>
+					<value>
+						<researchViewY>2</researchViewY>
+					</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+
+	<!--Apply patches to features that QEE and QE share-->
+	<Operation Class="PatchOperationFindMod">
+		<success>Always</success>
+		<mods>
+			<li>Questionable Ethics</li>
+			<li>Questionable Ethics Enhanced</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 			<operations>
@@ -193,52 +309,11 @@
 
 				<!--but wait the secondary arms still use it! nOPE!-->
 				<li Class="PatchOperationRemove">
-					<xpath>/Defs/RecipeDef[defName="EVO_InstallEvolvedArm_Secondary"]/ingredients/li[3]
+					<xpath>/Defs/RecipeDef[contains(defName, "EVO_InstallEvolvedArm")]/ingredients/li[3]
 					</xpath>
 				</li>
 				<li Class="PatchOperationRemove">
-					<xpath>/Defs/RecipeDef[defName="EVO_InstallEvolvedArm_Secondary"]/fixedIngredientFilter/thingDefs/li[2]
-					</xpath>
-				</li>
-				<li Class="PatchOperationRemove">
-					<xpath>/Defs/RecipeDef[defName="EVO_InstallEvolvedArmClaw_Secondary"]/ingredients/li[3]
-					</xpath>
-				</li>
-				<li Class="PatchOperationRemove">
-					<xpath>/Defs/RecipeDef[defName="EVO_InstallEvolvedArmClaw_Secondary"]/fixedIngredientFilter/thingDefs/li[2]
-					</xpath>
-				</li>
-				<li Class="PatchOperationRemove">
-					<xpath>/Defs/RecipeDef[defName="EVO_InstallEvolvedArmSabre_Secondary"]/ingredients/li[3]
-					</xpath>
-				</li>
-				<li Class="PatchOperationRemove">
-					<xpath>/Defs/RecipeDef[defName="EVO_InstallEvolvedArmSabre_Secondary"]/fixedIngredientFilter/thingDefs/li[2]
-					</xpath>
-				</li>
-				<li Class="PatchOperationRemove">
-					<xpath>/Defs/RecipeDef[defName="EVO_InstallEvolvedArmMace_Secondary"]/ingredients/li[3]
-					</xpath>
-				</li>
-				<li Class="PatchOperationRemove">
-					<xpath>/Defs/RecipeDef[defName="EVO_InstallEvolvedArmMace_Secondary"]/fixedIngredientFilter/thingDefs/li[2]
-					</xpath>
-				</li>
-				<li Class="PatchOperationRemove">
-					<xpath>/Defs/RecipeDef[defName="EVO_InstallEvolvedArmTentacle_Secondary"]/ingredients/li[3]
-					</xpath>
-				</li>
-				<li Class="PatchOperationRemove">
-					<xpath>/Defs/RecipeDef[defName="EVO_InstallEvolvedArmTentacle_Secondary"]/fixedIngredientFilter/thingDefs/li[2]
-					</xpath>
-				</li>
-				<li Class="PatchOperationRemove">
-					<xpath>/Defs/RecipeDef[defName="EVO_InstallEvolvedArmShield_Secondary"]/ingredients/li[3]
-					</xpath>
-				</li>
-				<li Class="PatchOperationRemove">
-					<xpath>/Defs/RecipeDef[defName="EVO_InstallEvolvedArmShield_Secondary"]/fixedIngredientFilter/thingDefs/li[2]
-					</xpath>
+					<xpath>/Defs/RecipeDef[contains(defName, "EVO_InstallEvolvedArm")]/fixedIngredientFilter/thingDefs/li[2]</xpath>
 				</li>
 
 				<!--Then we remove the bench altogether -->
@@ -253,7 +328,7 @@
         <li Class="PatchOperationReplace">
           <xpath>/Defs/ThingDef[defName="EvolvedChunk"]/description</xpath>
           <value>
-            <description>This has been deprecated, it has no use in this mod configuration with Questionable Ethics, either disassemble it at a crafting spot/machining workbench/drug lab or sell it to a trader.</description>
+            <description>This has been deprecated. It is not used when the mod is enabled with Questionable Ethics, so either disassemble it at a crafting spot/machining workbench/drug lab or sell it to a trader.</description>
           </value>
         </li>
         
@@ -324,57 +399,6 @@
 				<li Class="PatchOperationRemove">
 					<xpath>/Defs/ResearchTabDef[defName="EVO_EvolvedOrgansResearchTab"]</xpath>
 				</li>
-        <li Class="PatchOperationReplace"><!--moving this to 6x, 4y default is 4x, 4y-->
-          <xpath>/Defs/ResearchProjectDef[defName="QE_CrudeBionics"]/researchViewX</xpath>
-          <value>
-            <researchViewX>5</researchViewX>
-          </value>
-        </li>
-        <li Class="PatchOperationReplace">
-          <xpath>/Defs/ResearchProjectDef[defName="QE_CrudeBionics"]/researchViewY</xpath>
-          <value>
-            <researchViewY>3</researchViewY>
-          </value>
-        </li>
-        <li Class="PatchOperationReplace">
-          <!--moving this to 5x, 4y default is 5x, 3y-->
-          <xpath>/Defs/ResearchProjectDef[defName="QE_BrainScanning"]/researchViewX</xpath>
-          <value>
-            <researchViewX>4</researchViewX>
-          </value>
-        </li>
-        <li Class="PatchOperationReplace">
-          <xpath>/Defs/ResearchProjectDef[defName="QE_BrainScanning"]/researchViewY</xpath>
-          <value>
-            <researchViewY>4</researchViewY>
-          </value>
-        </li>
-        <li Class="PatchOperationReplace">
-          <!--moving this to 6x, 2y default is 3x, 3y-->
-          <xpath>/Defs/ResearchProjectDef[defName="QE_LifeSupportSystem"]/researchViewX</xpath>
-          <value>
-            <researchViewX>5</researchViewX>
-          </value>
-        </li>
-        <li Class="PatchOperationReplace">
-          <xpath>/Defs/ResearchProjectDef[defName="QE_LifeSupportSystem"]/researchViewY</xpath>
-          <value>
-            <researchViewY>2</researchViewY>
-          </value>
-        </li>
-        <li Class="PatchOperationReplace">
-          <!--moving this to 6x, 2y default is 4x, 3y-->
-          <xpath>/Defs/ResearchProjectDef[defName="QE_NerveStapling"]/researchViewX</xpath>
-          <value>
-            <researchViewX>5</researchViewX>
-          </value>
-        </li>
-        <li Class="PatchOperationReplace">
-          <xpath>/Defs/ResearchProjectDef[defName="QE_NerveStapling"]/researchViewY</xpath>
-          <value>
-            <researchViewY>1</researchViewY>
-          </value>
-        </li>
         
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ResearchProjectDef[defName="EvolvedOrgansResearch1"]</xpath>
@@ -389,7 +413,7 @@
 							<prerequisites>
 								<li>QE_OrganVat_SensoryOrgans</li>
 								<li>QE_OrganVat_Limbs</li>
-								<li>QE_IntegratedWeaponry</li>
+								<li>Bionics</li>
 								<li>QE_BrainScanning</li>
 							</prerequisites>
 							<requiredResearchBuilding>HiTechResearchBench</requiredResearchBuilding>
@@ -397,7 +421,7 @@
 								<li>MultiAnalyzer</li>
 							</requiredResearchFacilities>
 							<researchViewX>4</researchViewX>
-							<researchViewY>5</researchViewY>
+							<researchViewY>4</researchViewY>
 						</ResearchProjectDef>
 					</value>
 				</li>
@@ -419,7 +443,7 @@
 								<li>MultiAnalyzer</li>
 							</requiredResearchFacilities>
 							<researchViewX>5</researchViewX>
-							<researchViewY>5</researchViewY>
+							<researchViewY>4</researchViewY>
 						</ResearchProjectDef>
 					</value>
 				</li>
@@ -441,7 +465,7 @@
 								<li>MultiAnalyzer</li>
 							</requiredResearchFacilities>
 							<researchViewX>6</researchViewX>
-							<researchViewY>5</researchViewY>
+							<researchViewY>4</researchViewY>
 						</ResearchProjectDef>
 					</value>
 				</li>
@@ -463,7 +487,7 @@
 								<li>MultiAnalyzer</li>
 							</requiredResearchFacilities>
 							<researchViewX>7</researchViewX>
-							<researchViewY>5</researchViewY>
+							<researchViewY>4</researchViewY>
 						</ResearchProjectDef>
 					</value>
 				</li>
@@ -485,7 +509,7 @@
 								<li>MultiAnalyzer</li>
 							</requiredResearchFacilities>
 							<researchViewX>5</researchViewX>
-							<researchViewY>6</researchViewY>
+							<researchViewY>5</researchViewY>
 						</ResearchProjectDef>
 					</value>
 				</li>
@@ -507,7 +531,7 @@
 								<li>MultiAnalyzer</li>
 							</requiredResearchFacilities>
 							<researchViewX>6</researchViewX>
-							<researchViewY>6</researchViewY>
+							<researchViewY>5</researchViewY>
 						</ResearchProjectDef>
 					</value>
 				</li>
@@ -529,7 +553,7 @@
 								<li>MultiAnalyzer</li>
 							</requiredResearchFacilities>
 							<researchViewX>7</researchViewX>
-							<researchViewY>6</researchViewY>
+							<researchViewY>5</researchViewY>
 						</ResearchProjectDef>
 					</value>
 				</li>
@@ -552,7 +576,7 @@
 								<li>MultiAnalyzer</li>
 							</requiredResearchFacilities>
 							<researchViewX>8</researchViewX>
-							<researchViewY>5</researchViewY>
+							<researchViewY>4</researchViewY>
 						</ResearchProjectDef>
 					</value>
 				</li>
@@ -573,8 +597,8 @@
 							<requiredResearchFacilities>
 								<li>MultiAnalyzer</li>
 							</requiredResearchFacilities>
-							<researchViewX>8</researchViewX>
-							<researchViewY>6</researchViewY>
+							<researchViewX>9</researchViewX>
+							<researchViewY>4</researchViewY>
 						</ResearchProjectDef>
 					</value>
 				</li>

--- a/Patches/EVO_F_QuestionableEthics.xml
+++ b/Patches/EVO_F_QuestionableEthics.xml
@@ -12,7 +12,7 @@
 			<operations>
 
 				<li Class="PatchOperationReplace"> 
-					<!--moving this to 5x, 2y default is 3x, 3y-->
+					<!--moving this to 4x, 0y default is 3x, 3y-->
 					<xpath>/Defs/ResearchProjectDef[defName="QE_LifeSupportSystem"]/researchViewX</xpath>
 					<value>
 						<researchViewX>4</researchViewX>
@@ -40,7 +40,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace"> 
-					<!--moving this to 5x, 3y default is 4x, 4y-->
+					<!--moving this to 1x, 5y default is 4x, 4y-->
 					<xpath>/Defs/ResearchProjectDef[defName="QE_CrudeBionics"]/researchViewX</xpath>
 					<value>
 						<researchViewX>1</researchViewX>
@@ -55,7 +55,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<!--moving this to 4x, 4y default is 5x, 3y-->
+					<!--moving this to 2x, 5y default is 5x, 3y-->
 					<xpath>/Defs/ResearchProjectDef[defName="QE_IntegratedWeaponry"]/researchViewX</xpath>
 					<value>
 						<researchViewX>2</researchViewX>
@@ -69,7 +69,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<!--moving this to 4x, 4y default is 5x, 3y-->
+					<!--moving this to 2x, 2y default is 5x, 3y-->
 					<xpath>/Defs/ResearchProjectDef[defName="QE_GenomeSequencing"]/researchViewX</xpath>
 					<value>
 						<researchViewX>2</researchViewX>
@@ -83,7 +83,7 @@
 				</li>
 
 				<li Class="PatchOperationReplace">
-					<!--moving this to 4x, 4y default is 5x, 3y-->
+					<!--moving this to 3x, 2y default is 5x, 3y-->
 					<xpath>/Defs/ResearchProjectDef[defName="QE_VatGrownBeings"]/researchViewX</xpath>
 					<value>
 						<researchViewX>3</researchViewX>
@@ -98,7 +98,7 @@
 
 				
 				<li Class="PatchOperationReplace">
-					<!--moving this to 4x, 4y default is 5x, 3y-->
+					<!--moving this to 4x, 2y default is 5x, 3y-->
 					<xpath>/Defs/ResearchProjectDef[defName="QE_BrainScanning"]/researchViewX</xpath>
 					<value>
 						<researchViewX>4</researchViewX>
@@ -328,7 +328,7 @@
         <li Class="PatchOperationReplace">
           <xpath>/Defs/ThingDef[defName="EvolvedChunk"]/description</xpath>
           <value>
-            <description>This has been deprecated. It is not used when the mod is enabled with Questionable Ethics, so either disassemble it at a crafting spot/machining workbench/drug lab or sell it to a trader.</description>
+            <description>This has been deprecated. It is unused when the mod is enabled with Questionable Ethics, so either disassemble it at a crafting spot/machining workbench/drug lab, or sell it to a trader.</description>
           </value>
         </li>
         
@@ -338,7 +338,7 @@
             <RecipeDef>
               <defName>Disassemble_EvolvedChunk</defName>
               <label>disassemble evolved meat</label>
-              <description>Disassemble some evolved meat because its deprecated and not used with the questionable ethics patch.</description>
+              <description>Disassemble some evolved meat, because it's deprecated and unused when the Questionable Ethics mod is enabled.</description>
               <jobString>Disassembling evolved meat.</jobString>
               <workSpeedStat>SmithingSpeed</workSpeedStat>
               <effectWorking>Cook</effectWorking>
@@ -407,7 +407,7 @@
 							<defName>EvolvedOrgansResearch1</defName>
 							<tab>QE_ResearchTab</tab>
 							<label>Nano-Scale Cellular Engineering</label>
-							<description>By combining our knowledge of biology and bionics, we can engineer cells that have much more potential than anything created naturally.</description>
+							<description>Extract Humanoid Protein at the Butcher Table and create Mechanite Slurry at the Machining Table. Made possible through a synthesis of biology and bionics knowledge.</description>
 							<baseCost>4000</baseCost>
 							<techLevel>Spacer</techLevel>
 							<prerequisites>
@@ -431,8 +431,8 @@
 						<ResearchProjectDef>
 							<defName>EvolvedOrgansResearchOrgans1</defName>
 							<tab>QE_ResearchTab</tab>
-							<label>BioMechanical Organ Application</label>
-							<description>Through the selective processes of germinating and stimulating stem cells at the nano-scale with mechanites, it is possible to create simple internal organs.</description>
+							<label>Biomechanical Organ Evolution</label>
+							<description>Grow evolved organs for simple body parts, like the kidney and liver, at the Organ Vat. We've learned how to germinate and stimulate stem cells with mechanites.</description>
 							<baseCost>2000</baseCost>
 							<techLevel>Spacer</techLevel>
 							<prerequisites>
@@ -453,8 +453,8 @@
 						<ResearchProjectDef>
 							<defName>EvolvedOrgansResearchOrgans2</defName>
 							<tab>QE_ResearchTab</tab>
-							<label>Complex Organ Application</label>
-							<description>The continued understand of stem cells and mechanite integration has allowed the development of advanced cellular structures which can be utilized to create advanced interal organs.</description>
+							<label>Complex Organ Evolution</label>
+							<description>Grow evolved organs for complex body parts, like the heart and lungs, at the Organ Vat. Our development of advanced cellular structures continues!</description>
 							<baseCost>3000</baseCost>
 							<techLevel>Spacer</techLevel>
 							<prerequisites>
@@ -475,8 +475,8 @@
 						<ResearchProjectDef>
 							<defName>EvolvedOrgansResearchOrgans3</defName>
 							<tab>QE_ResearchTab</tab>
-							<label>Advanced Organ Application</label>
-							<description>The understanding of the most difficult bodily structures which would unlock the capacity to engineer the most complex organs and beyond.</description>
+							<label>Advanced Organ Evolution</label>
+							<description>Grow evolved organs for new body parts entirely, like the second lung and combat glands, at the Organ Vat. We are now the masters of organ bio-engineering.</description>
 							<baseCost>4000</baseCost>
 							<techLevel>Spacer</techLevel>
 							<prerequisites>
@@ -497,8 +497,8 @@
 						<ResearchProjectDef>
 							<defName>EvolvedOrgansResearchLimbs1</defName>
 							<tab>QE_ResearchTab</tab>
-							<label>Structural Organ Application</label>
-							<description>To create bones and musculature we must first understand how to propogate the cells and mechanites in load bearing configurations.</description>
+							<label>Structural Organ Evolution</label>
+							<description>Grow evolved limbs for simple body parts, like the arm and leg, at the Organ Vat. We've learned how to engineer cells and mechanites in a load-bearing configuration.</description>
 							<baseCost>2000</baseCost>
 							<techLevel>Spacer</techLevel>
 							<prerequisites>
@@ -519,8 +519,8 @@
 						<ResearchProjectDef>
 							<defName>EvolvedOrgansResearchLimbs2</defName>
 							<tab>QE_ResearchTab</tab>
-							<label>Complex Limb Strcutures</label>
-							<description>The capability to create simple load-bearing structures has been understood, now we must scale up the technology to apply and test it.</description>
+							<label>Complex Limb Structures</label>
+							<description>Grow new evolved limbs for the body, like the arm mace and arm tentacle, at the Organ Vat. We are now improving on the designs of thousands of years of evolution.</description>
 							<baseCost>3000</baseCost>
 							<techLevel>Spacer</techLevel>
 							<prerequisites>
@@ -541,8 +541,8 @@
 						<ResearchProjectDef>
 							<defName>EvolvedOrgansResearchLimbs3</defName>
 							<tab>QE_ResearchTab</tab>
-							<label>Advanced Limb Strcutures</label>
-							<description>The study of what can exist beyond the configurations nature has provided us.  GMO-Humanoid Limbs.  Is the sky the limit?</description>
+							<label>Advanced Limb Structures</label>
+							<description>Grow exotic evolved limbs for the body, like the spider and pinions, at the Organ Vat. GMO-Humanoid limbs...is the sky the limit?</description>
 							<baseCost>4000</baseCost>
 							<techLevel>Spacer</techLevel>
 							<prerequisites>
@@ -564,7 +564,7 @@
 							<defName>EvolvedOrgansResearchAdvanced1</defName>
 							<tab>QE_ResearchTab</tab>
 							<label>True Bio-Mechanical Integration NYI</label>
-							<description>Can we put a powerplant in a humanoid?  Not yet implemented just enjoy the thought though.</description>
+							<description>Can we put a powerplant in a humanoid? Not yet implemented... enjoy the thought, though!</description>
 							<baseCost>10000</baseCost>
 							<techLevel>Spacer</techLevel>
 							<prerequisites>
@@ -587,7 +587,7 @@
 							<defName>EvolvedOrgansResearchAdvanced2</defName>
 							<tab>QE_ResearchTab</tab>
 							<label>Advanced Bio-Mechanical Integration NYI</label>
-							<description>K we can, but now what? We get to finally coding in blaster weapons that you can mount on your arms for the arm god thats what, but thats not in yet so... wait patiently I guess.</description>
+							<description>K we can, but now what? We get to finally coding in blaster weapons that you can mount on your arms for the arm god thats what, but thats not in yet, so... wait patiently, I guess.</description>
 							<baseCost>20000</baseCost>
 							<techLevel>Spacer</techLevel>
 							<prerequisites>
@@ -612,7 +612,7 @@
 						<ThingDef ParentName="ResourceBase">
 							<defName>EVO_Mechanite_Slurry</defName>
 							<label>Mechanite Slurry</label>
-							<description>A vial of distilled water full of nano-scale mechanites ready to be combined with humanoid proteins to be grown into a advanced organ.  These machines were once capable of anything, however during the extraction process they have been rendered generally harmless and will only reactivate when provided data from a Organ Vat and provided a nutrient suspension to begin work.  Maybe someday there will be the concern about the dreaded "Grey Goo" disaster but that day is not today.</description>
+							<description>A vial of distilled water full of nano-scale mechanites. It can be combined with humanoid proteins and grown into an advanced organ at the Organ Vat. These machines were once capable of anything, but the extraction process rendered them harmless. They will only react when immersed in a nutrient solution inside an Organ Vat. Perhaps someday there will be concern about the dreaded "Grey Goo" disaster, but that day is not today.</description>
 							<graphicData>
 								<texPath>Things/Item/Resource/MechaniteSlurryVial</texPath>
 								<graphicClass>Graphic_Single</graphicClass>
@@ -642,7 +642,7 @@
 						<RecipeDef>
 							<defName>Make_Mechanite_Slurry</defName>
 							<label>extract mechanites</label>
-							<description>By utilizing more learned techniques and taking additional time, dissassemble a dead mechanoid into its component parts while being careful to preserve and capture the mechanites found inside.</description>
+							<description>Utilize specialized techniques to carefully dissassemble a dead mechanoid into its component parts. The mechanites inside will be added to a vial of distilled water.</description>
 							<jobString>Extracting mechanites.</jobString>
 							<workSpeedStat>SmithingSpeed</workSpeedStat>
 							<allowMixingIngredients>false</allowMixingIngredients>


### PR DESCRIPTION
Adds compatibility with the upcoming mod Questionable Ethics Enhanced (QEE). The changes for QEE have been rolled into the Questionable Ethics patch file, to keep maintenance of the patches for these mods low.

There are only 2 large changes to the existing QE patch:
* QE Research X,Y co-ordinate patches are isolated to Questionable Ethics only. QEE's research tree has been made compatible with Evolved Organs (no patches required).
* Descriptions for the Evolved Organs research have been updated to be a little more informative. This is to help players in-game know what they just researched and where to build/craft these items. I tried to keep the cool flavor text for each research item intact.
